### PR TITLE
Cache MacOS build dependencies

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -49,20 +49,23 @@ jobs:
     - name: Cache brew deps
       uses: actions/cache@v2
       with:
+        # Paths to cache:
+        # /usr/local/Homebrew - installation folder of Homebrew
+        # /usr/local/Cellar - installation folder of Homebrew formulae
+        # /usr/local/Frameworks, /usr/local/bin, /usr/local/opt - contain (links to) binaries installed by Homebrew formulae
+        # /usr/local/lib/python3.8 - Python3 packages installation
         path: |
-          /usr/local/Cellar
           /usr/local/Homebrew
+          /usr/local/Cellar
           /usr/local/Frameworks
           /usr/local/bin
-          /usr/lib/python*
           /usr/local/opt
-          /usr/local/lib
-        key: macos-build-${{ hashFiles('./datadog-agent-buildimages/macos/builder_setup.sh') }}
+          /usr/local/lib/python3.8
+        key: macos-build-cache-${{ hashFiles('./datadog-agent-buildimages/macos/builder_setup.sh') }}
 
     - name: Set up builder
       run: |
         bash ./datadog-agent-buildimages/macos/builder_setup.sh
-
 
     - name: Add certificates to temporary keychain
       env:


### PR DESCRIPTION
### What does this PR do?

Caches folders related to Homebrew, the Homebrew formulae and python3 installed during the builder setup, so they can be reused in later builds.
The cache key is generated from the contents of `builder_setup.sh`. Any change to the builder setup script will create a new cache entry.

### Motivation

Reduce build time.

Without caching:
- Agent 6: 1h25~1h35
- Agent 7: 1h10~1h20

With caching, cache hit:
- Agent 6: 1h00~1h10 (https://github.com/DataDog/datadog-agent-macos-build/actions/runs/282336352)
- Agent 7: 0h45~0h55 (https://github.com/DataDog/datadog-agent-macos-build/runs/1193099378?check_suite_focus=true)

With caching, cache miss:
- Agent 6: 1h25~1h35 [+ 2 minutes (upload to cache)]
- Agent 7: 1h10~1h20 [+ 2 minutes (upload to cache)] (https://github.com/DataDog/datadog-agent-macos-build/actions/runs/282149228)