### PR TITLE
Pin XCode version

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -32,6 +32,10 @@ jobs:
       with:
         submodules: 'true'
 
+    - name: Use XCode 11.7
+      run: |
+        sudo xcode-select -s /Applications/Xcode_11.7.app
+
     - name: Remove preinstalled brew packages
       run: |
         # The base box ships a few things that can have unwanted effects on the MacOS build.


### PR DESCRIPTION
### What does this PR do?

Pin XCode to version 11.7.

### Motivation

XCode default version will be updated to 12.0 on October 20: https://github.com/actions/virtual-environments/issues/1712.
We don't want to get a major version upgrade unintentionally.