### PR TITLE
Enable Dependabot updates for Git submodule

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This makes it so that the git submodule is updated daily if there are new commits on datadog-agent-buildimages
