### PR TITLE
Set GOMODCACHE

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -127,6 +127,8 @@ jobs:
         KEYCHAIN_PWD: ${{ secrets.KEYCHAIN_PASSWORD }}
         SIGN: "true"
       run: |
+        export GOMODCACHE=~/gomodcache
+        mkdir -p $GOMODCACHE
         bash ./datadog-agent-buildimages/macos/build_script.sh
 
     - name: Upload Agent .dmg


### PR DESCRIPTION
### What does this PR do?

Explicitly set `GOMODCACHE` to a writable folder so that the `inv deps` and the omnibus builds use it.

### Motivation

Fix broken MacOS builds.

### Additional notes

Requires https://github.com/DataDog/datadog-agent/pull/7907.