### PR TITLE
Add Mozilla CA certs to perl env for notarization

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -138,6 +138,13 @@ jobs:
         path: |
           ~/go/src/github.com/DataDog/datadog-agent/omnibus/pkg/*.dmg
 
+    - name: Add Mozilla certs to perl env for notarization
+      run: |
+        # xpath is a perl tool, without Mozilla:CA certs installed notarization may fail
+        # with SSL errors:
+        # 500 Can't verify SSL peers without knowing which Certificate Authorities to trust http://www.apple.com/DTDs/PropertyList-1.0.dtd
+        PERL_MM_USE_DEFAULT=1 cpan Mozilla::CA
+
     - name: Notarize build
       env:
         RELEASE_VERSION: ${{ github.event.inputs.release_version }}


### PR DESCRIPTION
### What does this PR do?

Before running `xpath` (a Perl tool), adds Mozilla's CA certs to the Perl env.

### Motivation

We're getting SSL errors due to missing certs when parsing the output of the notarization upload:
```
500 Can't verify SSL peers without knowing which Certificate Authorities to trust http://www.apple.com/DTDs/PropertyList-1.0.dtd
Handler couldn't resolve external entity at line 2, column 101, byte 140
error in processing external entity reference at line 2, column 101, byte 140:
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
====================================================================================================^
<plist version="1.0">
<dict>
 at /System/Library/Perl/Extras/5.18/darwin-thread-multi-2level/XML/Parser.pm line 187.
 ```