### PR TITLE
Fix macOS build failure due to failed cmake install

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -137,6 +137,7 @@ jobs:
         name: ${{ github.event.inputs.release_version }}-dmg
         path: |
           ~/go/src/github.com/DataDog/datadog-agent/omnibus/pkg/*.dmg
+        if-no-files-found: error
 
     - name: Add Mozilla certs to perl env for notarization
       run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -6,7 +6,7 @@ on:
       datadog_agent_ref:
         description: 'git ref to target on datadog-agent'
         required: false
-        default: 'master'
+        default: 'main'
       release_version:
         description: 'release.json version to target'
         required: false


### PR DESCRIPTION
### What does this PR do?

Updates the `datadog-agent-buildimages` submodules to include https://github.com/DataDog/datadog-agent-buildimages/pull/146.

Updates the default value of `datadog_agent_ref` to `main` (only used for manual testing).

Makes the `upload-artifact` Github Action fail instead of warn if the package to upload cannot be found.

Successful run: https://github.com/DataDog/datadog-agent-macos-build/runs/3029974124?check_suite_focus=true