### PR TITLE
[backport] Fix macOS build failure due to failed cmake install

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -6,7 +6,7 @@ on:
       datadog_agent_ref:
         description: 'git ref to target on datadog-agent'
         required: false
-        default: 'master'
+        default: 'main'
       release_version:
         description: 'release.json version to target'
         required: false
@@ -137,6 +137,7 @@ jobs:
         name: ${{ github.event.inputs.release_version }}-dmg
         path: |
           ~/go/src/github.com/DataDog/datadog-agent/omnibus/pkg/*.dmg
+        if-no-files-found: error
 
     - name: Add Mozilla certs to perl env for notarization
       run: |


### PR DESCRIPTION
### What does this PR do?

Backport of #33.

Updates the datadog-agent-buildimages submodules to include DataDog/datadog-agent-buildimages#146.

Updates the default value of datadog_agent_ref to main (only used for manual testing).

Makes the upload-artifact Github Action fail instead of warn if the package to upload cannot be found.