### PR TITLE
Enable read-only use of the omnibus s3 artifacts cache

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -136,6 +136,8 @@ jobs:
         KEYCHAIN_PWD: ${{ secrets.KEYCHAIN_PASSWORD }}
         INTEGRATION_WHEELS_CACHE_BUCKET: dd-agent-omnibus
         INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD: "true"
+        S3_OMNIBUS_CACHE_BUCKET: "dd-ci-datadog-agent-omnibus-cache-build-stable"
+        S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS: "true"
         SIGN: ${{ secrets.ENABLE_SIGN }}
       run: |
         export GOMODCACHE=~/gomodcache


### PR DESCRIPTION
This will allow the pipeline in this repo to pull Omnibus Software artifacts from the S3 cache bucket.

Note that if an artifact is missing in the cache, Omnibus will fail rather than downloading from the internet. I think this is ok for us, but we have to keep in mind that if we add a source that is macos-specific and won't be pre-cached by runs on Linux/Windows, we'll have to upload it manually to the bucket.