### PR TITLE
Pass --ignore-dependencies to brew remove

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -55,7 +55,7 @@ jobs:
 
         # In order to avoid such cases in the future where we use things we didn't expect to, we'd rather
         # start with a "clean" runner with the bare minimum, and only install the brew packages we require.
-        brew remove --force $(brew list --formula)
+        brew remove --force --ignore-dependencies $(brew list --formula)
 
     - name: Cache brew deps
       uses: actions/cache@v2


### PR DESCRIPTION
The current cleanup command fails, this is suggested in the error message.

Note: `remove`, `uninstall` and `rm` are all aliases for the same command.