### PR TITLE
Update IBM MQ toolkit to version 9.2.4.0

### DIFF
--- a/scripts/builder_setup.sh
+++ b/scripts/builder_setup.sh
@@ -69,6 +69,6 @@ echo 'eval `gimme '$GO_VERSION'`' >> ~/.build_setup
 
 # Install IBM MQ
 sudo mkdir -p /opt/mqm
-curl "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/mactoolkit/${IBM_MQ_VERSION}-IBM-MQ-Toolkit-MacX64.pkg" -o /tmp/mq_client.pkg
+curl "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/mactoolkit/${IBM_MQ_VERSION}-IBM-MQ-DevToolkit-MacX64.pkg" -o /tmp/mq_client.pkg
 sudo installer -pkg /tmp/mq_client.pkg -target /
 sudo rm -rf /tmp/mq_client.pkg

--- a/scripts/builder_setup.sh
+++ b/scripts/builder_setup.sh
@@ -26,7 +26,7 @@ export CMAKE_VERSION=3.18.2.2
 export GIMME_VERSION=1.5.4
 
 export GO_VERSION=1.17.11
-export IBM_MQ_VERSION=9.2.2.0
+export IBM_MQ_VERSION=9.2.4.0
 
 # Install or upgrade brew (will also install Command Line Tools)
 CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"


### PR DESCRIPTION
Version `9.2.2.0` is no longer available in the IBM MQ website. I am bumping to next lowest available version, `9.2.4.0`, to minimize the changes