### PR TITLE
Remove base ruby env during cleanup to prevent gem version issues

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -41,7 +41,7 @@ jobs:
       run: |
         sudo xcode-select -s /Applications/Xcode_11.7.app
 
-    - name: Remove preinstalled brew packages
+    - name: Remove preinstalled environment
       run: |
         # The base box ships a few things that can have unwanted effects on the MacOS build.
         # For instance, we compile Python in the pipeline. If Python finds some libraries while
@@ -55,7 +55,8 @@ jobs:
         # start with a "clean" runner with the bare minimum, and only install the brew packages we require.
         brew remove --force --ignore-dependencies $(brew list --formula)
 
-        # Also completely remove the ruby env
+        # Also completely remove the ruby env, otherwise some files remain after the formula uninstall,
+        # possibly causing gem version mismatch issues (eg. bundler).
         rm -rf /usr/local/lib/ruby
 
     - name: Cache brew deps

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -55,6 +55,9 @@ jobs:
         # start with a "clean" runner with the bare minimum, and only install the brew packages we require.
         brew remove --force --ignore-dependencies $(brew list --formula)
 
+        # Also completely remove the ruby env
+        rm -rf /usr/local/lib/ruby
+
     - name: Cache brew deps
       uses: actions/cache@v3.0.3
       with:

--- a/scripts/builder_setup.sh
+++ b/scripts/builder_setup.sh
@@ -19,7 +19,7 @@ set -e
 # 2. Update here the version of the formula to use.
 export PKG_CONFIG_VERSION=0.29.2
 export RUBY_VERSION=2.7.4
-export BUNDLER_VERSION=2.3.16
+export BUNDLER_VERSION=2.3.7
 export PYTHON_VERSION=3.8.11
 # Pin cmake version without sphinx-doc, which causes build issues
 export CMAKE_VERSION=3.18.2.2


### PR DESCRIPTION
Currently, our pre-build formula cleanup step removes all preinstalled formula from the macOS host, but it doesn't remove some leftover ruby env files.

These leftover files may cause issues when the cache isn't used (eg. when we change the builder setup, which causes a cache miss) - in these cases, there can be issues if the gems we install don't match the gem versions that are left over in the ruby env.

This notably caused issues in https://github.com/DataDog/datadog-agent-macos-build/pull/94, where we had to update the bundler version because the base image had a newer bundler gem version:
```
/usr/local/lib/ruby/gems/2.7.0/bin/bundle:23:in `load': cannot load such file -- /usr/local/lib/ruby/gems/2.7.0/gems/bundler-2.3.16/exe/bundle (LoadError)
	from /usr/local/lib/ruby/gems/2.7.0/bin/bundle:23:in `<main>'
````

(ruby was expecting bundler `2.3.16` to be there, but we were installing `2.3.6`).

For the sake of build reproducibility & not having builds break every time we want to update something in the builder just because the base image was updated, this PR completely removes the leftover ruby env, allowing us to install whichever gem versions we want, and allowing us to update gems only when we want to.

To test this, this also reverts bundler to 2.3.7, to force a build without the cache, and with a lower version than the preinstalled bundler version.