### PR TITLE
Add pilot jobs in Github workflows

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -14,6 +14,9 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      id:
+        description: 'run identifier'
+        required: false
       datadog_agent_ref:
         description: 'git ref to target on datadog-agent'
         required: false
@@ -28,6 +31,13 @@ on:
         required: false
 
 jobs:
+  id:
+    name: Workflow ID Provider
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{github.event.inputs.id}}
+        run: echo run identifier ${{ inputs.id }}
+
   macos_build:
     runs-on: macos-10.15
     defaults:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,9 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      id:
+        description: 'run identifier'
+        required: false
       datadog_agent_ref:
         description: 'git ref to target on datadog-agent'
         required: false
@@ -20,6 +23,13 @@ on:
         required: false
 
 jobs:
+  id:
+    name: Workflow ID Provider
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{github.event.inputs.id}}
+        run: echo run identifier ${{ inputs.id }}
+
   macos_test:
     runs-on: macos-10.15
     defaults:


### PR DESCRIPTION
This PR adds a 'dummy' job (let's call it a pilot) that will retrieve the Job ID and set it as a name of the first step.
In combination with https://github.com/DataDog/datadog-agent/pull/12678 this allows to retrieve the workflow that was triggered.