### PR TITLE
[tests] Add JUnit reports as artifacts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,3 +86,13 @@ jobs:
         export GOMODCACHE=~/gomodcache
         mkdir -p $GOMODCACHE
         bash ./scripts/test_script.sh
+
+    - name: Upload unit test reports
+      uses: actions/upload-artifact@v3
+      if: "${{ always() }}"
+      with:
+        name: junit-files
+        path: |
+          ~/go/src/github.com/DataDog/datadog-agent/test_output.json
+          ~/go/src/github.com/DataDog/datadog-agent/junit-tests_macos.tgz
+        if-no-files-found: error

--- a/scripts/test_script.sh
+++ b/scripts/test_script.sh
@@ -36,7 +36,7 @@ inv -e rtloader.install
 #inv -e rtloader.test
 
 # Run unit tests
-inv -e test --rerun-fails=2 --python-runtimes $PYTHON_RUNTIMES --coverage --race --profile --cpus 3
+inv -e test --rerun-fails=2 --python-runtimes $PYTHON_RUNTIMES --coverage --race --profile --cpus 3 --save-result-json "test_output.json" --junit-tar "junit-tests_macos.tgz"
 
 # Run invoke task tests
 python3 -m tasks.release_tests


### PR DESCRIPTION
Makes the test GitHub Action produce JUnit test reports, and make these available as artifacts.