### PR TITLE
Include env variables to properly construct nightly names

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -9,6 +9,8 @@ env:
   DEFAULT_RELEASE_VERSION: 'nightly-a7'
   DEFAULT_AGENT_MAJOR_VERSION: '7'
   DEFAULT_PYTHON_RUNTIMES: '3'
+  DEFAULT_BUCKET_BRANCH: 'nightly'
+  DEFAULT_GITLAB_PIPELINE_ID: '0'
 
 on:
   pull_request:
@@ -144,6 +146,8 @@ jobs:
         RELEASE_VERSION: ${{ github.event.inputs.release_version || env.DEFAULT_RELEASE_VERSION }}
         AGENT_MAJOR_VERSION: ${{ github.event.inputs.agent_major_version || env.DEFAULT_AGENT_MAJOR_VERSION }}
         PYTHON_RUNTIMES: ${{ github.event.inputs.python_runtimes || env.DEFAULT_PYTHON_RUNTIMES }}
+        BUCKET_BRANCH: ${{ github.event.inputs.bucket_branch || env.DEFAULT_BUCKET_BRANCH }}
+        CI_PIPELINE_ID: ${{ github.event.inputs.gitlab_pipeline_id || env.DEFAULT_GITLAB_PIPELINE_ID }}
         KEYCHAIN_NAME: "build.keychain"
         KEYCHAIN_PWD: ${{ secrets.KEYCHAIN_PASSWORD }}
         INTEGRATION_WHEELS_CACHE_BUCKET: dd-agent-omnibus


### PR DESCRIPTION
### What does this PR do?

Up until now, the nightly names didn't contain the `.pipeline.<ID>` like nightly packages for other systems. So now we have `datadog-agent-7.41.0-rc.3.git.80.6a3d555-1.dmg` but we want to have `datadog-agent-7.41.0-rc.3.git.80.6a3d555.pipeline.11191346-1.dmg`. This will be accompanied by a datadog-agent PR to actually send these variables.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->
