### PR TITLE
Add forgotten GH workflow inputs

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -31,6 +31,12 @@ on:
       python_runtimes:
         description: 'Included python runtimes in the build'
         required: false
+      bucket_branch:
+        description: 'Release branch we are building for'
+        required: false
+      gitlab_pipeline_id:
+        description: 'ID of Gitlab pipeline that triggered this build'
+        required: false
 
 jobs:
   id:


### PR DESCRIPTION
### What does this PR do?

Adds arguments from https://github.com/DataDog/datadog-agent-macos-build/pull/122 as GH workflow inputs, which is necessary to actually use them.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->
