### PR TITLE
Upgrading Golang to 1.18.9 (#124)

### DIFF
--- a/scripts/builder_setup.sh
+++ b/scripts/builder_setup.sh
@@ -30,7 +30,7 @@ export PYTHON_VERSION=3.8.11
 export CMAKE_VERSION=3.18.2.2
 export GIMME_VERSION=1.5.4
 
-export GO_VERSION=1.18.8
+export GO_VERSION=1.18.9
 # Newer version of IBM_MQ have a different name
 export IBM_MQ_VERSION=9.2.4.0-IBM-MQ-DevToolkit
 #export IBM_MQ_VERSION=9.2.2.0-IBM-MQ-Toolkit


### PR DESCRIPTION
### What does this PR do?

backport: Upgrading Golang to 1.18.9