### PR TITLE
macOS workflow import agent-version cache

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -102,11 +102,11 @@ jobs:
         VERSION: ${{ github.event.inputs.datadog_agent_ref || env.DEFAULT_DATADOG_AGENT_REF }}
       run: |
         bash ./scripts/clone_agent.sh
+        export VERSION_CACHE_CONTENT="${{github.event.inputs.version_cache}}"
+        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then echo "$VERSION_CACHE_CONTENT" > $HOME/go/src/github.com/DataDog/datadog-agent/agent-version.cache; fi
 
     - name: Set up builder
       run: |
-        export VERSION_CACHE_CONTENT="${{github.event.inputs.version_cache}}"
-        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then echo "$VERSION_CACHE_CONTENT" > $GOPATH/src/github.com/DataDog/datadog-agent/agent-version.cache; fi
         bash ./scripts/builder_setup.sh
 
     - name: Add certificates to temporary keychain

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -37,6 +37,9 @@ on:
       gitlab_pipeline_id:
         description: 'ID of Gitlab pipeline that triggered this build'
         required: false
+      version_cache:
+        description: 'Content of the agent-version.cache file'
+        required: false
 
 jobs:
   id:
@@ -102,6 +105,8 @@ jobs:
 
     - name: Set up builder
       run: |
+        export VERSION_CACHE_CONTENT="${{github.event.inputs.version_cache}}"
+        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then echo "$VERSION_CACHE_CONTENT" > $GOPATH/src/github.com/DataDog/datadog-agent/agent-version.cache; fi
         bash ./scripts/builder_setup.sh
 
     - name: Add certificates to temporary keychain


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds an input to the macos github workflow to receive the content of the agent-version.cache file.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

[PR#16279](https://github.com/DataDog/datadog-agent/pull/16279) implements a new ``agent-version.cache`` file that allows CI to cache the agent version from the beginning to the end of the pipeline execution. This file is usually stored on s3 but github runners doesn't have this access.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->
