### PR TITLE
Revert "Version cache is now in base64 + test workflow agent cache support"

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -38,7 +38,7 @@ on:
         description: 'ID of Gitlab pipeline that triggered this build'
         required: false
       version_cache:
-        description: 'Base 64-encoded content of the agent-version.cache file'
+        description: 'Content of the agent-version.cache file'
         required: false
 
 jobs:
@@ -102,9 +102,8 @@ jobs:
         VERSION: ${{ github.event.inputs.datadog_agent_ref || env.DEFAULT_DATADOG_AGENT_REF }}
       run: |
         bash ./scripts/clone_agent.sh
-        cd $HOME/go/src/github.com/DataDog/datadog-agent
         export VERSION_CACHE_CONTENT="${{github.event.inputs.version_cache}}"
-        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then base64 -d <(echo "$VERSION_CACHE_CONTENT") > ./agent-version.cache; fi
+        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then echo "$VERSION_CACHE_CONTENT" > $HOME/go/src/github.com/DataDog/datadog-agent/agent-version.cache; fi
 
     - name: Set up builder
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,9 +21,6 @@ on:
       python_runtimes:
         description: 'Included python runtimes in the build'
         required: false
-      version_cache:
-        description: 'Base 64-encoded content of the agent-version.cache file'
-        required: false
 
 jobs:
   id:
@@ -82,9 +79,6 @@ jobs:
         VERSION: ${{ github.event.inputs.datadog_agent_ref || env.DEFAULT_DATADOG_AGENT_REF }}
       run: |
         bash ./scripts/clone_agent.sh
-        cd $HOME/go/src/github.com/DataDog/datadog-agent
-        export VERSION_CACHE_CONTENT="${{github.event.inputs.version_cache}}"
-        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then base64 -d <(echo "$VERSION_CACHE_CONTENT") > ./agent-version.cache; fi
 
     - name: Set up builder
       run: |


### PR DESCRIPTION
Reverts DataDog/datadog-agent-macos-build#138.

The PR cannot be merged until the `datadog-agent` repository sends base64-encoded versions, otherwise it fails with `Invalid character in input stream.` ([example](https://github.com/DataDog/datadog-agent-macos-build/actions/runs/5248002691/jobs/9478908985))