### PR TITLE
Invalidate cache by bumping its version

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -95,7 +95,7 @@ jobs:
           /usr/local/bin
           /usr/local/opt
           /usr/local/lib/python3.9
-        key: macos-11-build-cache-${{ hashFiles('./scripts/builder_setup.sh') }}-v2
+        key: macos-11-build-cache-${{ hashFiles('./scripts/builder_setup.sh') }}-v3
 
     - name: Clone datadog-agent repository
       env:


### PR DESCRIPTION
### What does this PR do?

Invalidates cache to try to prevent errors with git clone of homebrew: https://github.com/DataDog/datadog-agent-macos-build/actions/runs/5408404838/jobs/9827440203

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->
