### PR TITLE
Use brew formulas from formulae.brew.sh

### DIFF
--- a/scripts/builder_setup.sh
+++ b/scripts/builder_setup.sh
@@ -41,6 +41,7 @@ export IBM_MQ_VERSION=9.2.4.0-IBM-MQ-DevToolkit
 #export IBM_MQ_VERSION=9.2.2.0-IBM-MQ-Toolkit
 
 # Install or upgrade brew (will also install Command Line Tools)
+rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
 CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 # Add our custom repository

--- a/scripts/builder_setup.sh
+++ b/scripts/builder_setup.sh
@@ -42,7 +42,8 @@ export IBM_MQ_VERSION=9.2.4.0-IBM-MQ-DevToolkit
 
 # Install or upgrade brew (will also install Command Line Tools)
 rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
-CI=1 HOMEBREW_NO_INSTALL_FROM_API=0 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+unset HOMEBREW_NO_INSTALL_FROM_API
+CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 # Add our custom repository
 brew tap DataDog/datadog-agent-macos-build

--- a/scripts/builder_setup.sh
+++ b/scripts/builder_setup.sh
@@ -42,7 +42,7 @@ export IBM_MQ_VERSION=9.2.4.0-IBM-MQ-DevToolkit
 
 # Install or upgrade brew (will also install Command Line Tools)
 rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
-CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+CI=1 HOMEBREW_NO_INSTALL_FROM_API=0 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 # Add our custom repository
 brew tap DataDog/datadog-agent-macos-build

--- a/scripts/builder_setup.sh
+++ b/scripts/builder_setup.sh
@@ -41,6 +41,15 @@ export IBM_MQ_VERSION=9.2.4.0-IBM-MQ-DevToolkit
 #export IBM_MQ_VERSION=9.2.2.0-IBM-MQ-Toolkit
 
 # Install or upgrade brew (will also install Command Line Tools)
+
+# NOTE: The macOS runner has HOMEBREW_NO_INSTALL_FROM_API set, which makes it
+# try to clone homebrew-core. At one point, cloning of homebrew-core started
+# returning the following error for us in about 50 % of cases:
+#     remote: fatal: object 80a071c049c4f2e465e0b1c40cfc6325005ab05b cannot be read
+#     remote: aborting due to possible repository corruption on the remote side.
+# Unsetting HOMEBREW_NO_INSTALL_FROM_API makes brew use formulas from
+# https://formulae.brew.sh/, thus avoiding cloning the repository, hence
+# avoiding the error.
 rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
 unset HOMEBREW_NO_INSTALL_FROM_API
 CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"


### PR DESCRIPTION
### What does this PR do?

The macOS runner has `HOMEBREW_NO_INSTALL_FROM_API` set, which makes it try to clone homebrew-core. At one point, cloning of homebrew-core started returning the following error for us in about 50 % of cases (example: :
```
    remote: fatal: object 80a071c049c4f2e465e0b1c40cfc6325005ab05b cannot be read
    remote: aborting due to possible repository corruption on the remote side.
```
Unsetting `HOMEBREW_NO_INSTALL_FROM_API` makes brew use formulas from https://formulae.brew.sh/, thus avoiding cloning the repository, hence avoiding the error.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->
