### PR TITLE
Publish the raw `junit*.xml` file

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,4 +107,5 @@ jobs:
         path: |
           ~/go/src/github.com/DataDog/datadog-agent/test_output.json
           ~/go/src/github.com/DataDog/datadog-agent/junit-tests_macos.tgz
+          ~/go/src/github.com/DataDog/datadog-agent/junit-out-base.xml
         if-no-files-found: error


### PR DESCRIPTION
### What does this PR do?

Publish the raw `junit*.xml` file in the artifacts of the GitHub workflow.

### Motivation

We need it to publish the MacOS test results in the GitLab pipeline by DataDog/datadog-agent#17950.

### Additional Notes

The newly published file should be used here: https://github.com/DataDog/datadog-agent/pull/17950/files#diff-548fbf3dc83a41929350b750d32f961ec22c7bd199422c290c521e43ccebf9aa

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
