### PR TITLE
[lint] increase timeout from default 25 min to 60 min

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -28,5 +28,5 @@ inv -e install-tools
 inv -e deps
 
 # Run go linters
-inv -e linter.go --cpus 3 --timeout 30m0s
+inv -e linter.go --cpus 3 --timeout 60
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -28,5 +28,5 @@ inv -e install-tools
 inv -e deps
 
 # Run go linters
-inv -e linter.go --cpus 3
+inv -e linter.go --cpus 3 --timeout 30m0s
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Increase lint timeout to 60 min

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We are obsering flakiness in `lint_macos` due to slower runner than usual 

https://github.com/DataDog/datadog-agent-macos-build/actions/runs/8520709850/job/23337384936

Increasing the timeout should allow for slow runner to complete the linting task

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->
