### PR TITLE
fix(base64): Prevent usage of file descriptor in base64 call

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -91,7 +91,7 @@ jobs:
         bash ./scripts/clone_agent.sh
         cd $HOME/go/src/github.com/DataDog/datadog-agent
         export VERSION_CACHE_CONTENT="${{github.event.inputs.version_cache}}"
-        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then base64 -d <(echo "$VERSION_CACHE_CONTENT") > ./agent-version.cache; fi
+        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then echo "$VERSION_CACHE_CONTENT" | base64 -d > ./agent-version.cache; fi
 
     - name: Set up builder
       run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,7 +41,7 @@ jobs:
         run: echo run identifier ${{ inputs.id }}
 
   macos_lint:
-    runs-on: macos-12
+    runs-on: macos-13
     defaults:
       run:
         shell: bash
@@ -82,7 +82,7 @@ jobs:
           /usr/local/bin
           /usr/local/opt
           /usr/local/lib/python3.11
-        key: macos-12-build-cache-${{ hashFiles('./scripts/builder_setup.sh') }}
+        key: macos-13-build-cache-${{ hashFiles('./scripts/builder_setup.sh') }}
 
     - name: Clone datadog-agent repository
       env:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -60,7 +60,7 @@ jobs:
         run: echo run identifier ${{ inputs.id }}
 
   macos_build:
-    runs-on: macos-12
+    runs-on: macos-13
     defaults:
       run:
         shell: bash
@@ -107,7 +107,7 @@ jobs:
           /usr/local/bin
           /usr/local/opt
           /usr/local/lib/python3.11
-        key: macos-12-build-cache-${{ hashFiles('./scripts/builder_setup.sh') }}-v2
+        key: macos-13-build-cache-${{ hashFiles('./scripts/builder_setup.sh') }}-v2
 
     - name: Clone datadog-agent repository
       env:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -116,7 +116,7 @@ jobs:
         bash ./scripts/clone_agent.sh
         cd $HOME/go/src/github.com/DataDog/datadog-agent
         export VERSION_CACHE_CONTENT="${{github.event.inputs.version_cache}}"
-        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then base64 -d <(echo "$VERSION_CACHE_CONTENT") > ./agent-version.cache; fi
+        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then echo "$VERSION_CACHE_CONTENT" | base64 -d > ./agent-version.cache; fi
         # Copy files used for the Omnibus ruby deps cache key
         # This is to work around a limitation of GitHub Actions' `hashFiles()` function which requires
         # files to be inside the workspace.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -100,7 +100,7 @@ jobs:
         bash ./scripts/clone_agent.sh
         cd $HOME/go/src/github.com/DataDog/datadog-agent
         export VERSION_CACHE_CONTENT="${{github.event.inputs.version_cache}}"
-        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then base64 -d <(echo "$VERSION_CACHE_CONTENT") > ./agent-version.cache; fi
+        if [ ! -z "$VERSION_CACHE_CONTENT" ]; then echo "$VERSION_CACHE_CONTENT" | base64 -d > ./agent-version.cache; fi
 
     - name: Set up builder
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
         run: echo run identifier ${{ inputs.id }}
 
   macos_test:
-    runs-on: macos-12
+    runs-on: macos-13
     defaults:
       run:
         shell: bash
@@ -91,7 +91,7 @@ jobs:
           /usr/local/bin
           /usr/local/opt
           /usr/local/lib/python3.11
-        key: macos-12-build-cache-${{ hashFiles('./scripts/builder_setup.sh') }}
+        key: macos-13-build-cache-${{ hashFiles('./scripts/builder_setup.sh') }}
 
     - name: Clone datadog-agent repository
       env:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Change the `base64 -d <(echo "$VERSION_CACHE_CONTENT")` syntax to use the equivalent `echo "$VERSION_CACHE_CONTENT" | base64 -d`, and migrate to `macos-13`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We tried to bump the runners to `macos-13` with #215. It led to [failures](https://github.com/DataDog/datadog-agent-macos-build/actions/runs/11324380576/job/31489344139) on the macos build jobs:
```
base64: invalid argument /dev/fd/63
Usage:	base64 [-hDd] [-b num] [-i in_file] [-o out_file]
```
`/dev/fd/63` is the file descriptor generated by the `<()` syntax (see details [here](https://unix.stackexchange.com/a/156088))
This new syntax was tested [here](https://github.com/chouetz/psychic-guacamole/actions/runs/11349640691)


### Additional Notes
Tested [here](https://github.com/chouetz/psychic-guacamole/actions/runs/11349669621) an alternative with `base64 -d  -i <(echo "$VERSION_CACHE_CONTENT")`. I find this syntax more complex, can be discussed

