### PR TITLE
Revert "[Backport 7.66.x] remove release_version from everywhere (#256)"

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -6,6 +6,7 @@ name: MacOS Agent build
 # Leaving an input empty will use the default value
 env:
   DEFAULT_DATADOG_AGENT_REF: 'main'
+  DEFAULT_RELEASE_VERSION: 'nightly'
   DEFAULT_AGENT_MAJOR_VERSION: '7'
   DEFAULT_PYTHON_RUNTIMES: '3'
   DEFAULT_BUCKET_BRANCH: 'nightly'
@@ -21,6 +22,9 @@ on:
         required: false
       datadog_agent_ref:
         description: 'git ref to target on datadog-agent'
+        required: false
+      release_version:
+        description: 'release.json version to target'
         required: false
       agent_major_version:
         description: 'Major version of the Agent to build'
@@ -183,6 +187,7 @@ jobs:
     - name: Run omnibus build
       env:
         VERSION: ${{ github.event.inputs.datadog_agent_ref || env.DEFAULT_DATADOG_AGENT_REF }}
+        RELEASE_VERSION: ${{ github.event.inputs.release_version || env.DEFAULT_RELEASE_VERSION }}
         AGENT_MAJOR_VERSION: ${{ github.event.inputs.agent_major_version || env.DEFAULT_AGENT_MAJOR_VERSION }}
         PYTHON_RUNTIMES: ${{ github.event.inputs.python_runtimes || env.DEFAULT_PYTHON_RUNTIMES }}
         BUCKET_BRANCH: ${{ github.event.inputs.bucket_branch || env.DEFAULT_BUCKET_BRANCH }}
@@ -212,7 +217,7 @@ jobs:
     - name: Upload Agent .dmg
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       with:
-        name: agent-dmg
+        name: ${{ github.event.inputs.release_version || env.DEFAULT_RELEASE_VERSION }}-dmg
         path: |
           ~/go/src/github.com/DataDog/datadog-agent/omnibus/pkg/*.dmg
         if-no-files-found: error
@@ -246,6 +251,7 @@ jobs:
     - name: Notarize build
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
       env:
+        RELEASE_VERSION: ${{ github.event.inputs.release_version || env.DEFAULT_RELEASE_VERSION }}
         APPLE_ACCOUNT: ${{ secrets.APPLE_ACCOUNT }}
         TEAM_ID: ${{ secrets.TEAM_ID }}
         NOTARIZATION_PWD: ${{ secrets.NOTARIZATION_PASSWORD }}

--- a/scripts/build_script.sh
+++ b/scripts/build_script.sh
@@ -17,6 +17,7 @@
 # - clone_agent.sh has been run
 # - builder_setup.sh has been run
 # - $VERSION contains the datadog-agent git ref to target
+# - $RELEASE_VERSION contains the release.json version to package. Defaults to $VERSION
 # - $AGENT_MAJOR_VERSION contains the major version to release
 # - $PYTHON_RUNTIMES contains the included python runtimes
 # - $SIGN set to true if signing is enabled
@@ -24,6 +25,7 @@
 #   - $KEYCHAIN_NAME contains the keychain name. Defaults to login.keychain
 #   - $KEYCHAIN_PWD contains the keychain password
 
+export RELEASE_VERSION=${RELEASE_VERSION:-$VERSION}
 export KEYCHAIN_NAME=${KEYCHAIN_NAME:-"login.keychain"}
 
 # Load build setup vars
@@ -68,9 +70,9 @@ fi
 if [ "$SIGN" = "true" ]; then
     # Unlock the keychain to get access to the signing certificates
     security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_NAME"
-    dda inv -e $INVOKE_TASK --hardened-runtime --major-version "$AGENT_MAJOR_VERSION" || exit 1
+    dda inv -e $INVOKE_TASK --hardened-runtime --major-version "$AGENT_MAJOR_VERSION" --release-version "$RELEASE_VERSION" || exit 1
     # Lock the keychain once we're done
     security lock-keychain "$KEYCHAIN_NAME"
 else
-    dda inv -e $INVOKE_TASK --skip-sign --major-version "$AGENT_MAJOR_VERSION" || exit 1
+    dda inv -e $INVOKE_TASK --skip-sign --major-version "$AGENT_MAJOR_VERSION" --release-version "$RELEASE_VERSION" || exit 1
 fi

--- a/scripts/notarization_script.sh
+++ b/scripts/notarization_script.sh
@@ -23,6 +23,8 @@
 # Load build setup vars
 source ~/.build_setup
 
+export RELEASE_VERSION=${RELEASE_VERSION:-$VERSION}
+
 unset LATEST_DMG
 
 # Find latest .dmg file in $GOPATH/src/github.com/Datadog/datadog-agent/omnibus/pkg


### PR DESCRIPTION
Reverts DataDog/datadog-agent-macos-build#257

revert this because we will directly run the release tasks in the `7.66.x` branch instead of main to minimize the number of backports and reduce variability